### PR TITLE
feat: add support for the Age header

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,21 @@ This is a distributed HTTP cache module for Caddy.
 
 ## Example Configuration
 
-See [`caddy_cache.json`](caddy_cache.json)
+See [`Caddyfile`](fixtures/Caddyfile) and [olricd.yaml](fixtures/olricd.yaml)
 
 ## TODO
 
 We are looking for volunteers to improve this module. Are you interested? Please comment in an issue!
 
+* [x] Add support for `Age`
 * [ ] Add support for `Vary`
-* [ ] Enable the distributed mode of Olric (our cache library)
+* [x] Enable the distributed mode of Olric (our cache library)
 * [ ] Allow to serve stale responses if the backend is down or while the new version is being generated
-* [ ] Add Caddyfile directives
+* [x] Add Caddyfile directives
+* [ ] Add support for the `stale-if-error` directive
+* [ ] Add support for the `stale-while-revalidate` directive
 * [ ] Add support for cache validation
+* [ ] Add support for request coalescing
 * [ ] Add support for cache invalidation (purge/ban)
 * [ ] Add support for cache tags (similar to Varnish ykey)
 * [ ] Add support for the `ttl` attribute of the `Cache-Status` header

--- a/age.go
+++ b/age.go
@@ -1,0 +1,61 @@
+// Copyright 2015 Matthew Holt and The Caddy Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpcache
+
+import (
+	"math"
+	"strconv"
+	"time"
+)
+
+// Specification of these calculations: https://httpwg.org/specs/rfc7234.html#age.calculations
+
+// apparent_age = max(0, response_time - date_value);
+//
+// response_delay = response_time - request_time;
+// corrected_age_value = age_value + response_delay;
+//
+// corrected_initial_age = max(apparent_age, corrected_age_value);
+func correctedInitialAge(responseTime, dateValue, requestTime time.Time, ageValue string) time.Duration {
+	apparentAge := responseTime.Sub(dateValue)
+	if apparentAge < 0 {
+		apparentAge = 0
+	}
+
+	var initialAge time.Duration
+	if ageValue != "" {
+		if iAgeValue, _ := strconv.Atoi(ageValue); iAgeValue != 0 {
+			initialAge = time.Duration(iAgeValue) * time.Second
+		}
+	}
+
+	responseDelay := responseTime.Sub(requestTime)
+	correctedAgeValue := initialAge + responseDelay
+
+	if apparentAge > correctedAgeValue {
+		return apparentAge
+	}
+	return correctedAgeValue
+}
+
+// resident_time = now - response_time;
+// current_age = corrected_initial_age + resident_time;
+func currentAge(responseTime time.Time, correctedInitialAge time.Duration) string {
+	return ageToString(correctedInitialAge + time.Now().UTC().Sub(responseTime))
+}
+
+func ageToString(age time.Duration) string {
+	return strconv.Itoa(int(math.Ceil(age.Seconds())))
+}

--- a/httpcache_test.go
+++ b/httpcache_test.go
@@ -1,6 +1,7 @@
 package httpcache_test
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/caddyserver/caddy/v2/caddytest"
@@ -55,6 +56,55 @@ func TestSMaxAge(t *testing.T) {
 	resp2, _ := tester.AssertGetResponse(`http://localhost:9080/cache-s-maxage`, 200, "Hello, s-maxage!")
 	if resp2.Header.Get("Cache-Status") != "Caddy; hit" {
 		t.Errorf("unexpected Cache-Status header %v", resp2.Header.Get("Cache-Status"))
+	}
+}
+
+func TestAgeHeader(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(` 
+	{
+		http_port     9080
+		https_port    9443
+	}
+	localhost:9080 {
+		route /age-header {
+			cache
+			header Cache-Control "max-age=60"
+			respond "Hello, Age header!"
+		}
+	}`, "caddyfile")
+
+	resp1, _ := tester.AssertGetResponse(`http://localhost:9080/age-header`, 200, "Hello, Age header!")
+	if resp1.Header.Get("Age") != "" {
+		t.Errorf("unexpected Age header %v", resp1.Header.Get("Age"))
+	}
+
+	resp2, _ := tester.AssertGetResponse(`http://localhost:9080/age-header`, 200, "Hello, Age header!")
+	if resp2.Header.Get("Age") == "" {
+		t.Error("Age header should be present")
+	}
+}
+
+func TestExistingAgeHeader(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(` 
+	{
+		http_port     9080
+		https_port    9443
+	}
+	localhost:9080 {
+		route /age-header {
+			cache
+			header Cache-Control "max-age=60"
+			header Age "max-age=5"
+			respond "Hello, Age header!"
+		}
+	}`, "caddyfile")
+
+	resp1, _ := tester.AssertGetResponse(`http://localhost:9080/age-header`, 200, "Hello, Age header!")
+	age, _ := strconv.Atoi(resp1.Header.Get("Age"))
+	if age <= 0 {
+		t.Errorf("unexpected Age header %v", resp1.Header.Get("Age"))
 	}
 }
 


### PR DESCRIPTION
Add support for the `Age` HTTP header according to https://httpwg.org/specs/rfc7234.html#age.calculations.