### PR TITLE
Caddyfile to run cache-tests

### DIFF
--- a/fixtures/cache-tests/Caddyfile
+++ b/fixtures/cache-tests/Caddyfile
@@ -1,0 +1,14 @@
+{
+    debug
+    experimental_http3
+    cache {
+        olric_config fixtures/olricd.yaml
+    }
+}
+
+localhost
+
+route * {
+    cache
+    reverse_proxy 127.0.0.1:8000
+}

--- a/fixtures/cache-tests/README.md
+++ b/fixtures/cache-tests/README.md
@@ -1,0 +1,18 @@
+# Cache-Tests
+
+Setup https://github.com/http-tests/cache-tests
+
+1) run the server `npm run server`
+2) run the tests `NODE_TLS_REJECT_UNAUTHORIZED=0 npm run cli --base=http://localhost --silent > results/caddy-cache-handler.json`
+3) to check the results you may want to add this to the `results/index.mjs`:
+
+```
+  {
+    file: 'caddy-cache-handler.json',
+    name: 'Caddy',
+    type: 'rev-proxy',
+    version: 'dev'
+  }
+```
+
+4) Open https://localhost


### PR DESCRIPTION
We may want to add Caddy to https://github.com/http-tests/cache-tests at some point. In the meantime these configuration files allow us to run the test suite. 

![Screenshot_2021-04-07 HTTP Caching Tests](https://user-images.githubusercontent.com/1321971/113876523-1cecf500-97b8-11eb-84c0-7f14a58d0a41.png)
